### PR TITLE
V1.3 reservation timing enhancement

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -242,7 +242,8 @@ Format:
   * Returns all reservations on **today's date**, at `TIME` 
 
 
-* `DATE` is formatted as `yyyy-MM-dd`, `TIME` is formatted as `HHmm`
+* `DATE` is formatted as `yyyy-MM-dd`
+* `TIME` has to be formatted on the hour as `HH00`
 
 Examples:
 * `check 2021-09-19 1800`
@@ -256,7 +257,8 @@ customer's phone number and the date & time.
 
 Format: `reserve NUMBER_OF_PEOPLE p/PHONE at/DATE_TIME`
 
-* Date-time format is `yyyy-MM-dd HHmm`, e.g. `2021-11-11 2030`
+* Date-time format is `yyyy-MM-dd HHmm`, e.g. `2021-11-11 2000`
+  * Time has to be formatted on the hour (i.e. `HH00`)
 
 Examples: 
 * `reserve 2 p/98765432 at/2021-12-24 2000`
@@ -344,7 +346,7 @@ Action | Format, Examples
 **Edit Employee** | `editemployee INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [l/LEAVES] [sal/SALARY] [jt/JOBTITLE] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com sal/7000`
 **Edit Supplier** | `editsupplier INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [st/SUPPLYTYPE] [dd/DELIVERYDETAILS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com st/Beef`
 **Edit Customer** | `editcustomer INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [alg/ALLERGIES] [sr/SPECIALREQUESTS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com alg/Kiwi`
-**Create reservation** | `reserve NUMBER_OF_PEOPLE p/PHONE at/DATE_TIME`<br> e.g., `reserve 2 p/98765432 at/2021-12-24 2000`
+**Set Tables** | `settables SIZE_OF_TABLES`<br> e.g., `settables 10x4,8x5,3,1x4`
 **Find [COMING SOON]** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **List [COMING SOON]** | `list`
 **Help [COMING SOON]** | `help`

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -25,4 +25,6 @@ public class Messages {
             "%1$d person(s) have reservations on %2$te %2$th %2$tY";
     public static final String MESSAGE_RESERVATIONS_LISTED_TIME_ONLY =
             "%1$d person(s) have reservations on %2$te %2$th %2$tY (Today), %2$tl:%2$tM %2$tp";
+    public static final String MESSAGE_INVALID_RESERVATION_MINUTES =
+            "Timing has to be on the hour (i.e. hh00)";
 }

--- a/src/main/java/seedu/address/logic/commands/ReserveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReserveCommand.java
@@ -22,8 +22,8 @@ public class ReserveCommand extends Command {
     public static final String COMMAND_WORD = "addr";
     public static final String MESSAGE_USAGE = String.format(
             "%1$s: add a new reservation with customer's phone number, number of people and time.\n"
-            + "Parameters: NUMBER_OF_PEOPLE %2$sPHONE (must be a positive integer) %3$sTIME\n"
-            + "Example: %1$s 2 %2$s98765432 %3$s2021-12-24 1930.",
+            + "Parameters: NUMBER_OF_PEOPLE %2$sPHONE (must be a positive integer) %3$sTIME (minutes must be 00)\n"
+            + "Example: %1$s 2 %2$s98765432 %3$s2021-12-24 1900.",
             COMMAND_WORD,
             PREFIX_PHONE, PREFIX_TIME
     );

--- a/src/main/java/seedu/address/logic/parser/CheckCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CheckCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_RESERVATION_MINUTES;
 import static seedu.address.logic.parser.ParserUtil.DATE_FORMATTER;
 import static seedu.address.logic.parser.ParserUtil.TIME_FORMATTER;
 
@@ -47,6 +48,9 @@ public class CheckCommandParser implements Parser<CheckCommand> {
         }
 
         parseArgs(splitTrimmedArgs);
+        if (time.getMinute() != 0) {
+            throw new ParseException(MESSAGE_INVALID_RESERVATION_MINUTES);
+        }
         return new CheckCommand(new ListContainsReservationPredicate(date, time, typeOfCheck));
     }
 

--- a/src/main/java/seedu/address/logic/parser/ReserveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ReserveCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_RESERVATION_MINUTES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 
@@ -27,6 +28,10 @@ public class ReserveCommandParser implements Parser<ReserveCommand> {
         int numberOfPeople = ParserUtil.parseNumberOfPeople(argMultimap.getPreamble());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         LocalDateTime time = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_TIME).get());
+
+        if (time.getMinute() != 0) {
+            throw new ParseException(MESSAGE_INVALID_RESERVATION_MINUTES);
+        }
 
         assert numberOfPeople > 0;
         assert phone.value.length() > 0;

--- a/src/main/java/seedu/address/model/reservation/ListContainsReservationPredicate.java
+++ b/src/main/java/seedu/address/model/reservation/ListContainsReservationPredicate.java
@@ -21,6 +21,7 @@ public class ListContainsReservationPredicate implements Predicate<Reservation> 
      * @param typeOfCheck enum specifying if user is checking for date, time or both
      */
     public ListContainsReservationPredicate(LocalDate date, LocalTime time, EnumTypeOfCheck typeOfCheck) {
+        assert time.getMinute() == 0;
         this.date = date;
         this.time = time;
         this.typeOfCheck = typeOfCheck;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -129,11 +129,11 @@ public class SampleDataUtil {
                     new Table(2, 10)),
             new Reservation(new Phone("91031282"), 4, LocalDateTime.parse("2021-11-11T13:00"),
                     new Table(4, 11)),
-            new Reservation(new Phone("93210283"), 2, LocalDateTime.parse("2021-12-25T19:30"),
+            new Reservation(new Phone("93210283"), 2, LocalDateTime.parse("2021-12-25T19:00"),
                     new Table(2, 12)),
             new Reservation(new Phone("99272758"), 3, LocalDateTime.parse("2021-10-30T19:00"),
                     new Table(3, 13)),
-            new Reservation(new Phone("87438807"), 6, LocalDateTime.parse("2021-02-14T11:30"),
+            new Reservation(new Phone("87438807"), 6, LocalDateTime.parse("2021-02-14T11:00"),
                     new Table(6, 14))
         };
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedReservation.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedReservation.java
@@ -18,6 +18,7 @@ public class JsonAdaptedReservation {
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Reservation's %s field is missing";
     public static final String NUMBER_OF_PEOPLE_CONSTRAINT = "Number of people should be a non-zero unsigned integer";
     public static final String DATE_TIME_CONSTRAINT = "Wrong date time format";
+    public static final String TIME_ON_THE_HOUR_CONSTRAINT = "Minutes of time is not 00";
     public static final String TABLE_ID_CONSTRAINT = "Table ID should be a non-zero unsigned integer";
 
     private final String phone;
@@ -85,6 +86,10 @@ public class JsonAdaptedReservation {
             throw new IllegalValueException(DATE_TIME_CONSTRAINT);
         }
         LocalDateTime modelTime = LocalDateTime.parse(time);
+
+        if (modelTime.getMinute() != 0) {
+            throw new IllegalValueException(TIME_ON_THE_HOUR_CONSTRAINT);
+        }
 
         if (tableId == null) {
             throw new IllegalValueException(

--- a/src/test/java/seedu/address/logic/commands/ReserveCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/ReserveCommandTestUtil.java
@@ -16,7 +16,7 @@ public class ReserveCommandTestUtil {
     public static final String VALID_PHONE_BOB = "22222222";
     public static final int VALID_NUMBER_OF_PEOPLE_AMY = 5;
     public static final int VALID_NUMBER_OF_PEOPLE_BOB = 2;
-    public static final String VALID_DATE_TIME_AMY = "2021-11-11 2030";
+    public static final String VALID_DATE_TIME_AMY = "2021-11-11 2000";
     public static final String VALID_DATE_TIME_BOB = "2021-12-01 1900";
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -223,7 +223,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_reserve() throws Exception {
         assertTrue(parser.parseCommand(
-                ReserveCommand.COMMAND_WORD + " 2 p/98765432 at/2021-11-11 2030") instanceof ReserveCommand
+                ReserveCommand.COMMAND_WORD + " 2 p/98765432 at/2021-11-11 2000") instanceof ReserveCommand
         );
     }
 

--- a/src/test/java/seedu/address/logic/parser/ReserveCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ReserveCommandParserTest.java
@@ -20,9 +20,9 @@ class ReserveCommandParserTest {
         ReserveCommand expected = new ReserveCommand(
                 new Phone("98765432"),
                 2,
-                LocalDateTime.parse("2021-11-11 2030", DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm")));
+                LocalDateTime.parse("2021-11-11 2000", DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm")));
 
-        assertParseSuccess(parser, "2 p/98765432 at/2021-11-11 2030", expected);
+        assertParseSuccess(parser, "2 p/98765432 at/2021-11-11 2000", expected);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalReservation.java
+++ b/src/test/java/seedu/address/testutil/TypicalReservation.java
@@ -18,7 +18,7 @@ public class TypicalReservation {
             CUSTOMER_ALICE.getPhone(), 2, LocalDateTime.parse("2021-11-11T20:00"), new Table(2, 10)
     );
     public static final Reservation BENSON_RESERVATION = new Reservation(
-            CUSTOMER_BENSON.getPhone(), 3, LocalDateTime.parse("2021-11-12T19:30"), new Table(3, 11)
+            CUSTOMER_BENSON.getPhone(), 3, LocalDateTime.parse("2021-11-12T19:00"), new Table(3, 11)
     );
     public static final Reservation CARL_RESERVATION = new Reservation(
             CUSTOMER_CARL.getPhone(), 3, LocalDateTime.parse("2021-11-11T09:00"), new Table(3, 12)


### PR DESCRIPTION
Add check for create reservation and check commands so that only timings on the hour can be accepted (aka timing has to be XX00, where the minutes is 00)

This prevents the case where a table is reserved for 1900 but is free for 1901.

Our view is that each reservation will last an hour each time

fixes #110 