### PR TITLE
Fix bugs in find command

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -60,6 +60,29 @@ public class StringUtil {
         String preppedSentence = sentence;
         return preppedSentence.toLowerCase().contains(preppedWord.toLowerCase());
     }
+
+    /**
+     * Returns true if the {@code sentence} contains the {@code substring}.
+     *   Ignores case, only requires a partial match in any fields.
+     *   <br>examples:<pre>
+     *       containsSubstringIgnoreCase("ABc def", "abc") == true
+     *       containsSubstringIgnoreCase("ABc def", "DEF") == true
+     *       containsSubstringIgnoreCase("ABc def", "AB") == true
+     *       </pre>
+     * @param sentence cannot be null
+     * @param word cannot be null, cannot be empty, can be single word
+     */
+    public static boolean containsSubstringNotSingleWordIgnoreCase(String sentence, String word) {
+        requireNonNull(sentence);
+        requireNonNull(word);
+
+        String preppedWord = word.trim();
+        checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
+
+        String preppedSentence = sentence;
+        return preppedSentence.toLowerCase().contains(preppedWord.toLowerCase());
+    }
+
     /**
      * Returns a detailed message of the t, including the stack trace.
      */

--- a/src/main/java/seedu/address/logic/commands/FindEmployeeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindEmployeeCommand.java
@@ -16,10 +16,10 @@ public class FindEmployeeCommand extends Command {
     public static final String COMMAND_WORD = "finde";
 
     public static final String MESSAGE_USAGE = CommandUtil.formatCommandWord(COMMAND_WORD)
-            + ": Finds all employees that contain any of "
+            + ": Finds all employees that contain "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + CommandUtil.formatCommandWord(COMMAND_WORD) + " alice 14 days $1200";
+            + "Example: " + CommandUtil.formatCommandWord(COMMAND_WORD) + " 2021-12-08 0800";
 
     private final EmployeeClassContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindEmployeeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindEmployeeCommandParser.java
@@ -25,9 +25,9 @@ public class FindEmployeeCommandParser implements Parser<FindEmployeeCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindEmployeeCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        //String[] nameKeywords = trimmedArgs.split("\\s+");
 
-        return new FindEmployeeCommand(new EmployeeClassContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindEmployeeCommand(new EmployeeClassContainsKeywordsPredicate(Arrays.asList(trimmedArgs)));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/customer/CustomerClassContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/customer/CustomerClassContainsKeywordsPredicate.java
@@ -18,7 +18,7 @@ public class CustomerClassContainsKeywordsPredicate implements Predicate<Custome
     @Override
     public boolean test(Customer customer) {
         return keywords.stream()
-                .anyMatch(keyword ->
+                .allMatch(keyword ->
                     StringUtil.containsSubstringIgnoreCase(
                             customer.getName().fullName, keyword)
                             || StringUtil.containsSubstringIgnoreCase(

--- a/src/main/java/seedu/address/model/person/employee/EmployeeClassContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/employee/EmployeeClassContainsKeywordsPredicate.java
@@ -18,24 +18,24 @@ public class EmployeeClassContainsKeywordsPredicate implements Predicate<Employe
     @Override
     public boolean test(Employee employee) {
         return keywords.stream()
-                .anyMatch(keyword ->
-                        StringUtil.containsSubstringIgnoreCase(
+                .allMatch(keyword ->
+                        StringUtil.containsSubstringNotSingleWordIgnoreCase(
                                 employee.getName().fullName, keyword)
-                                || StringUtil.containsSubstringIgnoreCase(
+                                || StringUtil.containsSubstringNotSingleWordIgnoreCase(
                                 employee.getEmail().value, keyword)
-                                || StringUtil.containsSubstringIgnoreCase(
+                                || StringUtil.containsSubstringNotSingleWordIgnoreCase(
                                 employee.getPhone().value, keyword)
-                                || StringUtil.containsSubstringIgnoreCase(
+                                || StringUtil.containsSubstringNotSingleWordIgnoreCase(
                                 employee.getAddress().value, keyword)
-                                || StringUtil.containsSubstringIgnoreCase(
+                                || StringUtil.containsSubstringNotSingleWordIgnoreCase(
                                 employee.getLeaves().currentLeaves, keyword)
-                                || StringUtil.containsSubstringIgnoreCase(
+                                || StringUtil.containsSubstringNotSingleWordIgnoreCase(
                                 employee.getJobTitle().jobTitle, keyword)
-                                || StringUtil.containsSubstringIgnoreCase(
+                                || StringUtil.containsSubstringNotSingleWordIgnoreCase(
                                 employee.getSalary().currentSalary, keyword)
-                                || StringUtil.containsSubstringIgnoreCase(
+                                || StringUtil.containsSubstringNotSingleWordIgnoreCase(
                                 employee.getShifts().toString(), keyword)
-                                || StringUtil.containsSubstringIgnoreCase(
+                                || StringUtil.containsSubstringNotSingleWordIgnoreCase(
                                 employee.getTags().toString(), keyword)
                 );
     }

--- a/src/main/java/seedu/address/model/person/employee/Shift.java
+++ b/src/main/java/seedu/address/model/person/employee/Shift.java
@@ -29,8 +29,8 @@ public class Shift {
         requireNonNull(shift);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
         checkArgument(isValidShift(shift), MESSAGE_CONSTRAINTS);
-        shiftString = shift;
         workingShift = LocalDateTime.parse(shift, formatter);
+        shiftString = this.workingShift.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/supplier/SupplierClassContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/supplier/SupplierClassContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class SupplierClassContainsKeywordsPredicate implements Predicate<Supplie
     @Override
     public boolean test(Supplier supplier) {
         return keywords.stream()
-                .anyMatch(keyword ->
+                .allMatch(keyword ->
                          StringUtil.containsSubstringIgnoreCase(
                                  supplier.getName().fullName, keyword)
                                  || StringUtil.containsSubstringIgnoreCase(

--- a/src/test/java/seedu/address/logic/commands/FindCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCustomerCommandTest.java
@@ -5,9 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_CUSTOMERS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CustomerCommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalCustomers.CUSTOMER_CARL;
-import static seedu.address.testutil.TypicalCustomers.CUSTOMER_ELLE;
-import static seedu.address.testutil.TypicalCustomers.CUSTOMER_FIONA;
 import static seedu.address.testutil.TypicalCustomers.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -15,9 +12,11 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.customer.Customer;
 import seedu.address.model.person.customer.CustomerClassContainsKeywordsPredicate;
 
 /**
@@ -55,23 +54,25 @@ public class FindCustomerCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_CUSTOMERS_LISTED_OVERVIEW, 0);
+    public void execute_zeroKeywords_allPersonsFound() {
+        String expectedMessage = String.format(MESSAGE_CUSTOMERS_LISTED_OVERVIEW,
+                model.getFilteredCustomerList().size());
+        ObservableList<Customer> customersList = model.getFilteredCustomerList();
         CustomerClassContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCustomerCommand command = new FindCustomerCommand(predicate);
         expectedModel.updateFilteredCustomerList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredCustomerList());
+        assertEquals(customersList, model.getFilteredCustomerList());
     }
 
     @Test
-    public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_CUSTOMERS_LISTED_OVERVIEW, 3);
+    public void execute_multipleKeywords_multiplePersonsNamesNotFound() {
+        String expectedMessage = String.format(MESSAGE_CUSTOMERS_LISTED_OVERVIEW, 0);
         CustomerClassContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCustomerCommand command = new FindCustomerCommand(predicate);
         expectedModel.updateFilteredCustomerList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CUSTOMER_CARL, CUSTOMER_ELLE, CUSTOMER_FIONA), model.getFilteredCustomerList());
+        assertEquals(Collections.emptyList(), model.getFilteredCustomerList());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -163,7 +163,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_findEmployee() throws Exception {
-        List<String> keywords = Arrays.asList("goo", "far", "daz");
+        List<String> keywords = Arrays.asList("goo far daz");
         FindEmployeeCommand command = (FindEmployeeCommand) parser.parseCommand(
                 FindEmployeeCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindEmployeeCommand(new EmployeeClassContainsKeywordsPredicate(keywords)), command);

--- a/src/test/java/seedu/address/model/person/customer/CustomerClassContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/customer/CustomerClassContainsKeywordsPredicateTest.java
@@ -52,10 +52,6 @@ public class CustomerClassContainsKeywordsPredicateTest {
         predicate = new CustomerClassContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new CustomerBuilder().withName("Alice Bob").build()));
 
-        // Only one matching keyword
-        predicate = new CustomerClassContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        assertTrue(predicate.test(new CustomerBuilder().withName("Alice Carol").build()));
-
         // Mixed-case keywords
         predicate = new CustomerClassContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
         assertTrue(predicate.test(new CustomerBuilder().withName("Alice Bob").build()));
@@ -65,14 +61,18 @@ public class CustomerClassContainsKeywordsPredicateTest {
                 "alice@email.com", "Main", "Street"));
         assertTrue(predicate.test(new CustomerBuilder().withName("Alice").withPhone("12345")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
+
+        // Zero keywords
+        predicate = new CustomerClassContainsKeywordsPredicate(Collections.emptyList());
+        assertTrue(predicate.test(new CustomerBuilder().withName("Alice").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
+        // Only one matching keyword
         CustomerClassContainsKeywordsPredicate predicate =
-                new CustomerClassContainsKeywordsPredicate(Collections.emptyList());
-        assertFalse(predicate.test(new CustomerBuilder().withName("Alice").build()));
+                new CustomerClassContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
+        assertFalse(predicate.test(new CustomerBuilder().withName("Alice Carol").build()));
 
         // Non-matching keyword
         predicate = new CustomerClassContainsKeywordsPredicate(Arrays.asList("Carol"));

--- a/src/test/java/seedu/address/model/person/employee/EmployeeClassContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/employee/EmployeeClassContainsKeywordsPredicateTest.java
@@ -52,10 +52,6 @@ public class EmployeeClassContainsKeywordsPredicateTest {
         predicate = new EmployeeClassContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new EmployeeBuilder().withName("Alice Bob").build()));
 
-        // Only one matching keyword
-        predicate = new EmployeeClassContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        assertTrue(predicate.test(new EmployeeBuilder().withName("Alice Carol").build()));
-
         // Mixed-case keywords
         predicate = new EmployeeClassContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
         assertTrue(predicate.test(new EmployeeBuilder().withName("Alice Bob").build()));
@@ -65,14 +61,18 @@ public class EmployeeClassContainsKeywordsPredicateTest {
                 Arrays.asList("12345", "alice@email.com", "Main", "Street"));
         assertTrue(predicate.test(new EmployeeBuilder().withName("Alice").withPhone("12345")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
+
+        // Zero keywords
+        predicate = new EmployeeClassContainsKeywordsPredicate(Collections.emptyList());
+        assertTrue(predicate.test(new EmployeeBuilder().withName("Alice").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
+        // Only one matching keyword
         EmployeeClassContainsKeywordsPredicate predicate =
-                new EmployeeClassContainsKeywordsPredicate(Collections.emptyList());
-        assertFalse(predicate.test(new EmployeeBuilder().withName("Alice").build()));
+                new EmployeeClassContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
+        assertFalse(predicate.test(new EmployeeBuilder().withName("Alice Carol").build()));
 
         // Non-matching keyword
         predicate = new EmployeeClassContainsKeywordsPredicate(Arrays.asList("Carol"));

--- a/src/test/java/seedu/address/model/person/supplier/SupplierClassContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/supplier/SupplierClassContainsKeywordsPredicateTest.java
@@ -55,18 +55,12 @@ public class SupplierClassContainsKeywordsPredicateTest {
 
         // Only one matching keyword
         predicate = new SupplierClassContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        assertTrue(predicate.test(new SupplierBuilder().withName("Alice Carol").build()));
+        assertFalse(predicate.test(new SupplierBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
         predicate = new SupplierClassContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB", "fRiEnDs", "NoVEmBER"));
         assertTrue(predicate.test(new SupplierBuilder().withName("Alice Bob").withTags("friends")
                 .withDeliveryDetails("2021-11-19 15:00").build()));
-
-        // Keywords match phone, email and address, but does not match anything else
-        predicate = new SupplierClassContainsKeywordsPredicate(
-                Arrays.asList("12345", "alice@email.com", "Main", "Street", "Beef", "Feb", "Fish", "Regular"));
-        assertTrue(predicate.test(new SupplierBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 
     @Test
@@ -74,7 +68,13 @@ public class SupplierClassContainsKeywordsPredicateTest {
         // Zero keywords
         SupplierClassContainsKeywordsPredicate predicate =
                 new SupplierClassContainsKeywordsPredicate(Collections.emptyList());
-        assertFalse(predicate.test(new SupplierBuilder().withName("Alice").build()));
+        assertTrue(predicate.test(new SupplierBuilder().withName("Alice").build()));
+
+        // Keywords match phone, email and address, but does not match anything else
+        predicate = new SupplierClassContainsKeywordsPredicate(
+                Arrays.asList("12345", "alice@email.com", "Main", "Street", "Beef", "Feb", "Fish", "Regular"));
+        assertFalse(predicate.test(new SupplierBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").build()));
 
         // Non-matching keyword
         predicate = new SupplierClassContainsKeywordsPredicate(Arrays.asList("Carol", "Beef", "Jan", "Texas"));


### PR DESCRIPTION
Find Command has some bugs in how we want it to work in customers, employees and suppliers side. 

Changed Employee find to be able to find shifts but more restrictive in the way to find (eg find 2021-12-08 0800) is treated as 1 find keyword

Changed Customer and Supplier to be to find people that match ALL keywords instead of find people that match ANY keyword.

Closes #132 