### PR TITLE
Fix PE-D issues

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -81,7 +81,7 @@ This is the list of all prefixes used in RHRH, as well as their corresponding pa
 |  `l/`  | Leaves              | Leaves should only contain numbers
 | `jt/`  | Job Title           | Job Title should only contain alphanumeric characters and spaces, and should not be left blank
 | `sal/` | Salary              | Salary should contain numbers and should be at least 3 numbers long
-| `sh/`  | Shift (Optional)    | Format: `yyyy-MM-dd HHmm`, e.g. `2021-12-08 0800`. One entity can have multiple shifts <br> When editing shifts, the existing values of shifts will be replaced, i.e editing of these fields are not cumulative <br> If you want to remove all shifts from an entity, you can use `editE INDEX sh/` without specifying any shifts after it 
+| `sh/`  | Shift (Optional)    | Format: `yyyy-MM-dd HHmm`, e.g. `2021-12-08 0800`. One entity can have multiple shifts <br> When editing shifts, the existing values of shifts will be replaced, i.e editing of these fields are not cumulative <br> If you want to remove all shifts from an entity, you can use `editE INDEX sh/` without specifying any shifts after it <br> **NOTE**: Shifts CAN be in the past, present or future. Flexibility is given to the restaurant on how they want to use it 
 | `st/`  | Supply Type         | Supply types should only contain alphanumeric characters and spaces, and it should not be blank
 | `dd/`  | Delivery Details    | Refer [here](#adding-a-supplier-adds) for more details
 | `at/`  | Reserving Date Time | Format: `yyyy-MM-dd HHmm`, e.g. `2021-12-24 2000` |
@@ -158,6 +158,9 @@ Action | Format, Examples
 
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `resetC`, `resetE`, `resetS`, `listC`, `listE`, `listS`, `listR`, `exit` and `clear`) will be ignored.<br>
  e.g. if the command specifies `help 123`, it will be interpreted as `help`.
+  
+* If the user's interface is showing a different list, they can use specific commands to go to another window with a that specific list. 
+ <br> e.g. If user's interface shows `Customers` list, they can use other Employee related commands such as `addE`, `editE` or `listE` etc. to change the interface to show `employees`.
 
 </div>
 
@@ -480,7 +483,7 @@ Format: `findE KEYWORDS`
 * Displays all employees that contain the specified keywords **together**.
 
 Examples:
-* `findE 2021-12-08 0800`: Finds employees that have `2021-12-08 0800` in any of their fields.
+* `findE 2021-12-08 0800`: Finds employees that are working on `shift` `2021-12-08 0800`.
 
 * `findE Team A`: Finds all employees that have `Team A` in any of their fields.
 
@@ -566,7 +569,7 @@ Example:
 
 ### Displaying a sorted list of customers: `sortC`
 
-Sorts and displays the list of customers based on a given field in either ascending or descending order.
+Sorts and displays the active list of customers based on a given field in either ascending or descending order.
 
 Format: `sortC by/PREFIX_OF_CUSTOMER_FIELD o/ORDER_OF_SORT`
 
@@ -585,11 +588,13 @@ Examples:
     * For example `n` for name and `lp` for loyalty points
 * The only acceptable inputs for the `ORDER_OF_SORT` parameter are `a` for `ascending` and `d` for `descending`.
 * `ALLERGIES`, `SPECIAL REQUESTS` & `TAG` are not fields that can be used to sort customers.
+* `sortC` only sorts the active current list for customers.
+    * e.g. If you findC previously and only 3 customers are displayed on the list, `sortC` will only sort the 3 customers
 
 </div>
 
 ### Displaying a sorted list of employees: `sortE`
-Sorts and displays the list of employees based on a given field in either ascending or descending order.
+Sorts and displays the active list of employees based on a given field in either ascending or descending order.
 
 Format: `sortE by/PREFIX_OF_EMMPLOYEE_FIELD o/ORDER_OF_SORT`
 * Sorts and displays the list of employees based on the sort type
@@ -608,11 +613,13 @@ Examples:
     * For example `n` for name and `sal` for salary
 * The only acceptable inputs for the `ORDER_OF_SORT` parameter are `a` for `ascending` and `d` for `descending`.
 * `SHIFT` & `TAG` are not fields that can be used to sort employees.
+* `sortE` only sorts the active current list for employees.
+    * e.g. If you findE previously and only 3 employees are displayed on the list, `sortE` will only sort the 3 employees
 
 </div>
 
 ### Displaying a sorted list of suppliers: `sortS`
-Sorts and displays the list of suppliers based on a given field in either ascending or descending order.
+Sorts and displays the active list of suppliers based on a given field in either ascending or descending order.
 
 Format: `sortS by/PREFIX_OF_SUPPLIER_FIELD o/ORDER_OF_SORT`
 
@@ -632,6 +639,8 @@ Examples:
   * For example `n` for name and `dd` for delivery details
 * The only acceptable inputs for the `ORDER_OF_SORT` parameter are `a` for `ascending` and `d` for `descending`.
 * `TAG` is not a field that can be used to sort suppliers.
+* `sortS` only sorts the active current list for suppliers.
+    * e.g. If you findS previously and only 3 suppliers are displayed on the list, `sortS` will only sort the 3 suppliers
 
 
 </div>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -159,8 +159,8 @@ Action | Format, Examples
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `resetC`, `resetE`, `resetS`, `listC`, `listE`, `listS`, `listR`, `exit` and `clear`) will be ignored.<br>
  e.g. if the command specifies `help 123`, it will be interpreted as `help`.
   
-* If the user's interface is showing a different list, they can use specific commands to go to another window with a that specific list. 
- <br> e.g. If user's interface shows `Customers` list, they can use other Employee related commands such as `addE`, `editE` or `listE` etc. to change the interface to show `employees`.
+* Users can use all customer/employee/supplier commands apart from  listC listE and listS to switch to the customer/employee/supplier list respectively
+ <br> e.g. If a user is currently viewing the customer list, using `addE`, `editE`, `sortE` etc. while the customer list is active will execute the respective employee command and switch to the employee list automatically
 
 </div>
 
@@ -590,6 +590,7 @@ Examples:
 * `ALLERGIES`, `SPECIAL REQUESTS` & `TAG` are not fields that can be used to sort customers.
 * `sortC` only sorts the active current list for customers.
     * e.g. If you findC previously and only 3 customers are displayed on the list, `sortC` will only sort the 3 customers
+* If a filtered list with no customer listed is shown, `sortC` will be invalid.
 
 </div>
 
@@ -615,6 +616,7 @@ Examples:
 * `SHIFT` & `TAG` are not fields that can be used to sort employees.
 * `sortE` only sorts the active current list for employees.
     * e.g. If you findE previously and only 3 employees are displayed on the list, `sortE` will only sort the 3 employees
+* If a filtered list with no employee listed is shown, `sortE` will be invalid.
 
 </div>
 
@@ -641,6 +643,7 @@ Examples:
 * `TAG` is not a field that can be used to sort suppliers.
 * `sortS` only sorts the active current list for suppliers.
     * e.g. If you findS previously and only 3 suppliers are displayed on the list, `sortS` will only sort the 3 suppliers
+* If a filtered list with no supplier listed is shown, `sortS` will be invalid.
 
 
 </div>

--- a/src/main/java/seedu/address/logic/commands/AddEmployeeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEmployeeCommand.java
@@ -32,18 +32,18 @@ public class AddEmployeeCommand extends Command {
             + PREFIX_LEAVES + " LEAVES "
             + PREFIX_SALARY + " SALARY "
             + PREFIX_JOBTITLE + " JOB TITLE "
-            + "[" + PREFIX_SHIFT + "SHIFT]"
+            + "[" + PREFIX_SHIFT + "SHIFT]... "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + CommandUtil.formatCommandWord(COMMAND_WORD) + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_LEAVES + "14"
-            + PREFIX_SALARY + "5000"
-            + PREFIX_JOBTITLE + "Account Manager"
-            + PREFIX_SHIFT + "2021-12-24 0800"
-            + PREFIX_TAG + "SEA";
+            + PREFIX_LEAVES + "14 "
+            + PREFIX_SALARY + "5000 "
+            + PREFIX_JOBTITLE + "Head Chef "
+            + PREFIX_SHIFT + "2021-12-24 0800 "
+            + PREFIX_TAG + "Team C";
 
     public static final String MESSAGE_SUCCESS = "New employee has been added: %1$s";
     public static final String MESSAGE_DUPLICATE_EMPLOYEE = "Employee information already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/AddSupplierCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSupplierCommand.java
@@ -27,7 +27,7 @@ public class AddSupplierCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TAG + "TAG]"
+            + "[" + PREFIX_TAG + "TAG] "
             + PREFIX_SUPPLY_TYPE + "TYPE OF SUPPLY "
             + PREFIX_DELIVERY_DETAILS + "DELIVERY DETAILS...\n"
             + "Example: " + CommandUtil.formatCommandWord(COMMAND_WORD) + " "

--- a/src/main/java/seedu/address/logic/commands/EditEmployeeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEmployeeCommand.java
@@ -58,7 +58,7 @@ public class EditEmployeeCommand extends Command {
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + CommandUtil.formatCommandWord(COMMAND_WORD) + " 1 "
             + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com"
+            + PREFIX_EMAIL + "johndoe@example.com "
             + PREFIX_SALARY + "4000";
 
     public static final String MESSAGE_EDIT_EMPLOYEE_SUCCESS = "Edited Employee: %1$s";

--- a/src/main/java/seedu/address/model/person/customer/UniqueCustomerList.java
+++ b/src/main/java/seedu/address/model/person/customer/UniqueCustomerList.java
@@ -119,6 +119,7 @@ public class UniqueCustomerList implements Iterable<Customer> {
      * Resets the supplier list to its default sorting state.
      */
     public void resetCustomerListToDefaultSortState() {
+        customerComparator = CustomerComparator.getDefaultComparator();
         internalList.sort(CustomerComparator.getDefaultComparator());
     }
 

--- a/src/main/java/seedu/address/model/person/customer/UniqueCustomerList.java
+++ b/src/main/java/seedu/address/model/person/customer/UniqueCustomerList.java
@@ -120,7 +120,7 @@ public class UniqueCustomerList implements Iterable<Customer> {
      */
     public void resetCustomerListToDefaultSortState() {
         customerComparator = CustomerComparator.getDefaultComparator();
-        internalList.sort(CustomerComparator.getDefaultComparator());
+        internalList.sort(customerComparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/employee/Salary.java
+++ b/src/main/java/seedu/address/model/person/employee/Salary.java
@@ -33,7 +33,11 @@ public class Salary {
      * Returns true if a given string is a valid salary.
      */
     public static boolean isValidSalary(String test) {
-        return test.matches(VALIDATION_REGEX);
+        try {
+            return Integer.parseInt(test) >= 100;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/employee/UniqueEmployeeList.java
+++ b/src/main/java/seedu/address/model/person/employee/UniqueEmployeeList.java
@@ -108,7 +108,7 @@ public class UniqueEmployeeList implements Iterable<Employee> {
      */
     public void resetEmployeeListToDefaultSortState() {
         employeeComparator = EmployeeComparator.getDefaultComparator();
-        internalList.sort(EmployeeComparator.getDefaultComparator());
+        internalList.sort(employeeComparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/employee/UniqueEmployeeList.java
+++ b/src/main/java/seedu/address/model/person/employee/UniqueEmployeeList.java
@@ -107,6 +107,7 @@ public class UniqueEmployeeList implements Iterable<Employee> {
      * Resets the employee list to its default sorting state.
      */
     public void resetEmployeeListToDefaultSortState() {
+        employeeComparator = EmployeeComparator.getDefaultComparator();
         internalList.sort(EmployeeComparator.getDefaultComparator());
     }
 

--- a/src/main/java/seedu/address/model/person/supplier/UniqueSupplierList.java
+++ b/src/main/java/seedu/address/model/person/supplier/UniqueSupplierList.java
@@ -116,7 +116,7 @@ public class UniqueSupplierList implements Iterable<Supplier> {
      */
     public void resetSupplierListToDefaultSortState() {
         supplierComparator = SupplierComparator.getDefaultComparator();
-        internalList.sort(SupplierComparator.getDefaultComparator());
+        internalList.sort(supplierComparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/supplier/UniqueSupplierList.java
+++ b/src/main/java/seedu/address/model/person/supplier/UniqueSupplierList.java
@@ -115,6 +115,7 @@ public class UniqueSupplierList implements Iterable<Supplier> {
      * Resets the supplier list to its default sorting state.
      */
     public void resetSupplierListToDefaultSortState() {
+        supplierComparator = SupplierComparator.getDefaultComparator();
         internalList.sort(SupplierComparator.getDefaultComparator());
     }
 

--- a/src/test/java/seedu/address/model/person/employee/SalaryTest.java
+++ b/src/test/java/seedu/address/model/person/employee/SalaryTest.java
@@ -23,10 +23,8 @@ public class SalaryTest {
 
     @Test
     public void isValidSalary() {
-        // null Salary
-        assertThrows(NullPointerException.class, () -> Salary.isValidSalary(null));
-
         // invalid salary
+        assertFalse(Salary.isValidSalary(null)); // null salary
         assertFalse(Salary.isValidSalary("")); // empty string
         assertFalse(Salary.isValidSalary(" ")); // spaces only
         assertFalse(Salary.isValidSalary("91")); // less than 3 numbers


### PR DESCRIPTION
Fixed the following issues
- Close #154  addE(the author says findE but picture shows addE) now has no formatting issues
- Close #155 Salary now has a different validation method
- Close #159 Shift field can still allow paste dates, updated UserGuide to tell people that it is allowed for flexibility
- Close #161 Sort function still acts the same, but UserGuide now adds an extra note that it sorts *active* list
- Close #165,  Close #166,  close #168 added a note in UserGuide that commands that are specific to one type can be used to switch interface list(if anyone has problems with the wording pls help change, my english is not the best)
- Close #172 findE description changed because someone thinks its too confusing.
- Close #162 Fixed a bug that sorts based on previous sorting if we call reset.